### PR TITLE
fix(test): BookServiceTest - Fixed missing BookMapper mocks

### DIFF
--- a/backend/src/test/java/com/technicalchallenge/service/BookServiceTest.java
+++ b/backend/src/test/java/com/technicalchallenge/service/BookServiceTest.java
@@ -3,6 +3,7 @@ package com.technicalchallenge.service;
 import com.technicalchallenge.dto.BookDTO;
 import com.technicalchallenge.model.Book;
 import com.technicalchallenge.repository.BookRepository;
+import com.technicalchallenge.mapper.BookMapper; // Add missing import
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -12,12 +13,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class BookServiceTest {
     @Mock
     private BookRepository bookRepository;
+    @Mock
+    private BookMapper bookMapper; // Add missing mock
     @InjectMocks
     private BookService bookService;
 
@@ -25,7 +29,16 @@ public class BookServiceTest {
     void testFindBookById() {
         Book book = new Book();
         book.setId(1L);
+
+        // Add missing DTO entity mock
+        BookDTO bookDTO = new BookDTO();
+        bookDTO.setId(1L);
+
         when(bookRepository.findById(1L)).thenReturn(Optional.of(book));
+
+        // Add missing mapper call mock
+        when(bookMapper.toDto(book)).thenReturn(bookDTO);
+
         Optional<BookDTO> found = bookService.getBookById(1L);
         assertTrue(found.isPresent());
         assertEquals(1L, found.get().getId());
@@ -33,13 +46,22 @@ public class BookServiceTest {
 
     @Test
     void testSaveBook() {
+        BookDTO inputDTO = new BookDTO();
+        inputDTO.setId(2L);
+
         Book book = new Book();
         book.setId(2L);
-        BookDTO bookDTO = new BookDTO();
-        bookDTO.setId(2L);
+
+        BookDTO expectedDTO = new BookDTO();
+        expectedDTO.setId(2L);
+        
+        // Add mapper call mocks
+        when(bookMapper.toEntity(inputDTO)).thenReturn(book);
+        when(bookMapper.toDto(book)).thenReturn(expectedDTO);
+
         when(bookRepository.save(any(Book.class))).thenReturn(book);
 
-        BookDTO saved = bookService.saveBook(bookDTO);
+        BookDTO saved = bookService.saveBook(inputDTO);
         assertNotNull(saved);
         assertEquals(2L, saved.getId());
     }

--- a/docs/test-fixes-template.md
+++ b/docs/test-fixes-template.md
@@ -60,3 +60,10 @@ fix(test): TradeServiceTest - Fixed date validation error response
 - Root Cause: Test assertion had placeholder error message instead of actual business rule validation message 
 - Solution: Updated the assertEquals() assertion to expect the correct error message
 - Impact: Enables meaningful user date validation prompts for data validation in accordance with business rules
+
+fix(test): BookServiceTest - Fixed missing BookMapper mocks
+
+- Problem: testFindBookById, testFindBookByNonExistentId, testSaveBook had NullPointer errors because mapper methods returned null
+- Root Cause: The BookMapper mocks were missing - toDto() and toEntity() method calls were not mocked
+- Solution: Added BookMapper mocks for toDto() and toEntity() methods with proper return values
+- Impact: Enables comprehensive testing of BookService methods with proper DTO/Entity conversion


### PR DESCRIPTION
- Problem: testFindBookById, testFindBookByNonExistentId, testSaveBook had NullPointer errors because mapper methods returned null
- Root Cause: The BookMapper mocks were missing - toDto() and toEntity() method calls were not mocked
- Solution: Added BookMapper mocks for toDto() and toEntity() methods with proper return values
- Impact: Enables comprehensive testing of BookService methods with proper DTO/Entity conversion